### PR TITLE
Change the way to do the release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         make venv
     - name: Build package
-      run: make build
+      run: make dist
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ tox-with-system-python:
 build:
 	$(PYTHON_BIN)python setup.py build
 	$(PYTHON_BIN)python setup.py install
+
+dist:
+	$(PYTHON_BIN)python setup.py build
+	$(PYTHON_BIN)python setup.py sdist


### PR DESCRIPTION
Change the `install` to `sdist` in order to make it compatible with multiple python versions