### PR TITLE
chore: Support Django 5.2 LTS and 6.x, update deps and tox/CI matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,12 +10,34 @@ on:
     branches: [ main ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        make venv
+    - name: Lint
+      run: |
+        make lint
+
   build:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        include:
+          - python-version: "3.10"
+            tox-env: "py310-django42-tests,py310-django52-tests"
+          - python-version: "3.11"
+            tox-env: "py311-django42-tests,py311-django52-tests"
+          - python-version: "3.12"
+            tox-env: "py312-django42-tests,py312-django52-tests,py312-django60-tests"
 
     steps:
     - uses: actions/checkout@v4
@@ -26,12 +48,9 @@ jobs:
     - name: Install dependencies
       run: |
         make venv
-    - name: Lint
-      run: |
-        make lint
     - name: Test
       run: |
-        make tox-with-system-python
+        .venv/bin/tox -e ${{ matrix.tox-env }}
     - name: Build
       run: |
         make build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-all:
 	$(PYTHON_BIN)tox
 
 tox-with-system-python:
-	$(PYTHON_BIN)tox -e py
+	$(PYTHON_BIN)tox --skip-missing-interpreters
 
 build:
 	$(PYTHON_BIN)python setup.py build

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ Usage
 -----
 
 Requirements
-Python (3.10+; Django 6.x requires Python 3.12+)
-Django (4.2, 5.2 LTS, 6.x)
+Python (3.10–3.12; Django 6.x requires Python 3.12+)
+Django (4.2, 5.2 LTS, 6.0)
 Django REST Framework (3.15+)
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ Usage
 -----
 
 Requirements
-Python (3.10, 3.11, 3.12)
-Django (4.1, 4.2)
-Django REST Framework (3.13+)
+Python (3.10+; Django 6.x requires Python 3.12+)
+Django (4.2, 5.2 LTS, 6.x)
+Django REST Framework (3.15+)
 
 Installation
 ~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         "Framework :: Django :: 4.2",
-        "Framework :: Django :: 5.0",
-        "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Framework :: Django :: 6.0",
         'Intended Audience :: Developers',
@@ -66,6 +64,5 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        'django-constance[database]',
+        'django-constance',
         'factory_boy',
         'pytest',
         'pytest-cov',
@@ -39,11 +39,11 @@ setup(
     author='Loadsmart',
     author_email='developer@loadsmart.com',
     install_requires=[
-        'django>=4.1,<5',
-        'djangorestframework>=3.13,<4',
+        'django>=4.2,<7',
+        'djangorestframework>=3.15,<4',
         'django-picklefield',
-        'django-constance>=2,<3',
-        'django-waffle>=2,<3',
+        'django-constance>=3,<6',
+        'django-waffle>=3,<6',
     ],
     python_requires='>=3.10',
     extras_require=extras_require,
@@ -53,8 +53,11 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
+        "Framework :: Django :: 6.0",
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
@@ -63,5 +66,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,23 @@
 [tox]
-envlist=
-    py{310,311,312}-tests
-    docs
+envlist =
+    py310-django{42,52}-tests
+    py311-django{42,52}-tests
+    py312-django{42,52,60}-tests
     lint
 
 [testenv]
-usedevelop=True
-commands = pytest {posargs:tests} --cov-append --cov-report=xml --cov=frontend_settings
-extras=
+usedevelop = True
+extras =
     test
-setenv=
+setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONPATH={toxinidir}
-deps=
-    Django>=4.1,<5
-    djangorestframework>=3.13,<4
+deps =
+    django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
+commands =
+    pytest {posargs:tests} --cov-append --cov-report=xml --cov=frontend_settings
 allowlist_externals=make
 
 [testenv:lint]
@@ -23,7 +26,3 @@ commands =
     flake8 ./frontend_settings ./tests --ignore=E501
     isort --check-only --diff ./frontend_settings ./tests
     black --check --diff ./frontend_settings ./tests
-
-; [testenv:docs]
-; extras = doc
-; commands = make build-docs


### PR DESCRIPTION
## Summary

Widens supported Django versions so projects on **5.2 LTS** and **6.x** can depend on this package without fighting the old `<5` pin.

## What changed

- **Dependencies:** Raise floors/ceilings for Django, DRF, django-constance, and django-waffle; drop the invalid `django-constance[database]` test extra (picklefield stays a direct dependency).
- **CI:** Lint once; test matrix covers **Django 4.2 / 5.2 / 6.0** (6.0 on Python 3.12 only).
- **Tox:** Same matrix locally; `make tox-with-system-python` runs full tox and skips missing Python versions.
- **Docs:** README requirements updated to match.

## Upgrade note

Apps still on **Django 4.1** or very old **constance/waffle** majors will need to move to at least **Django 4.2** and **constance/waffle 3+** before upgrading this release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python version support to 3.10+
  * Extended Django compatibility to versions 4.2, 5.2 LTS, and 6.x (requires Python 3.12+)
  * Updated minimum dependency versions: Django REST Framework 3.15+, django-constance 3+, django-waffle 3+
  * Enhanced CI/CD testing to validate all supported Python-Django combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->