### PR TITLE
Update vulnerable PyPI publish action and scope release permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,10 +17,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -29,7 +32,10 @@ jobs:
     - name: Build package
       run: make dist
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
+        # Attestations only apply to Trusted Publishing (OIDC); this job uses
+        # token auth, so disable them explicitly to avoid an id-token requirement.
+        attestations: false


### PR DESCRIPTION
Hardens the PyPI release workflow (`python-publish.yml`) based on a `zizmor` static analysis.

### Changes
- **Update the vulnerable publish action.** `pypa/gh-action-pypi-publish` was pinned to a commit (`27b3170`, ~v1.4.2) belonging to a release affected by **GHSA-vxmw-7h4f-hqxh**. Bumped to **v1.14.0**, pinned to its commit SHA.
- **Scope job permissions.** The `deploy` job ran with default (broad) `GITHUB_TOKEN` scopes while publishing via `secrets.PYPI_TOKEN`. Added a least-privilege `permissions: contents: read` block.
- **Pin and upgrade the remaining actions.** `actions/checkout@v2` → `v4.2.2` and `actions/setup-python@v2` → `v5.6.0`, both pinned to commit SHAs with version comments.
- **Disable attestations explicitly.** v1.14.0 defaults `attestations: true`, which only applies to Trusted Publishing (OIDC). This job uses token auth, so `attestations: false` is set to keep behavior unchanged and avoid an implicit `id-token: write` requirement.

### Compatibility
No change to package source, version, or any published artifact — this only touches the release pipeline, so existing consumers are unaffected. Token-based auth (`user: __token__` + `PYPI_TOKEN`) is preserved (no migration to Trusted Publishing). The workflow runs only `on: release: published`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD publishing workflow with improved security configurations and pinned action versions for consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loadsmart/django-frontend-settings/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->