### PR TITLE
fix: batch-load waffle flags to avoid per-flag Redis N+1

### DIFF
--- a/frontend_settings/utils.py
+++ b/frontend_settings/utils.py
@@ -73,7 +73,9 @@ def _bind_prefetched_membership(flag) -> None:
     flag._get_group_ids = lambda ids=group_ids: ids
 
 
-def _evaluate_flags(flags: Iterable, request: HttpRequest, prefix: str) -> Dict[str, bool]:
+def _evaluate_flags(
+    flags: Iterable, request: HttpRequest, prefix: str
+) -> Dict[str, bool]:
     result: Dict[str, bool] = {}
     for flag in flags:
         _bind_prefetched_membership(flag)

--- a/frontend_settings/utils.py
+++ b/frontend_settings/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 import waffle
 from constance import config as constance_config
@@ -43,24 +43,55 @@ class _CachedRequest:
         return getattr(self._request, key)
 
 
+def _request_with_cached_user_groups(request: HttpRequest) -> HttpRequest:
+    """Evaluate flags without re-querying request.user.groups per flag."""
+    user = getattr(request, "user", None)
+    if not (user and user.is_authenticated):
+        return request
+
+    group_ids = tuple(user.groups.all().values_list("pk", flat=True))
+    return _CachedRequest(request, _CachedUser(user, group_ids))
+
+
+def _bind_prefetched_membership(flag) -> None:
+    """
+    Point waffle's per-flag users/groups lookups at already-prefetched M2M rows.
+
+    ``Flag.is_active`` normally calls ``_get_user_ids`` / ``_get_group_ids``, which
+    each do a Redis ``GET`` (and possibly a DB query). After ``prefetch_related``,
+    iterating ``flag.users`` / ``flag.groups`` is in-memory; binding those id sets
+    keeps ``is_active`` off the N+1 Redis path while reusing waffle's evaluation.
+    """
+    if not hasattr(flag, "_get_user_ids") or not hasattr(flag, "_get_group_ids"):
+        return
+
+    user_ids = frozenset(user.pk for user in flag.users.all())
+    group_ids = frozenset(group.pk for group in flag.groups.all())
+
+    # Default-arg binding avoids accidental late closure capture if refactored.
+    flag._get_user_ids = lambda ids=user_ids: ids
+    flag._get_group_ids = lambda ids=group_ids: ids
+
+
+def _evaluate_flags(flags: Iterable, request: HttpRequest, prefix: str) -> Dict[str, bool]:
+    result: Dict[str, bool] = {}
+    for flag in flags:
+        _bind_prefetched_membership(flag)
+        key = flag.name.replace(prefix, "", 1)
+        result[key] = flag.is_active(request)
+    return result
+
+
 def get_flags(request: HttpRequest) -> Dict[str, bool]:
     prefix = settings.WAFFLE_FLAG_PREFIX
-    request_with_cached_groups = request
-    user = getattr(request, "user", None)
-    if user and user.is_authenticated:
-        group_ids = tuple(user.groups.all().values_list("pk", flat=True))
-        request_with_cached_groups = _CachedRequest(
-            request, _CachedUser(user, group_ids)
-        )
+    request_with_cached_groups = _request_with_cached_user_groups(request)
 
     model = waffle.get_waffle_flag_model()
-    flags = model.objects.filter(name__startswith=prefix).values_list("name", flat=True)
-    return {
-        name.replace(prefix, "", 1): waffle.flag_is_active(
-            request_with_cached_groups, name
-        )
-        for name in flags
-    }
+    flags = model.objects.filter(name__startswith=prefix).prefetch_related(
+        "users",
+        "groups",
+    )
+    return _evaluate_flags(flags, request_with_cached_groups, prefix)
 
 
 def get_settings() -> Dict[str, Any]:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,12 +120,14 @@ def test_avoids_n_plus_one_on_user_groups(client):
 
 
 def _select_queries_matching(captured, pattern: str):
-    return [
-        query
-        for query in captured.captured_queries
-        if re.search(pattern, query["sql"], re.IGNORECASE)
-        and re.search(r"^\s*SELECT\b", query["sql"], re.IGNORECASE)
-    ]
+    matching = []
+    for query in captured.captured_queries:
+        sql = query["sql"]
+        if not re.search(r"^\s*SELECT\b", sql, re.IGNORECASE):
+            continue
+        if re.search(pattern, sql, re.IGNORECASE):
+            matching.append(query)
+    return matching
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+import waffle
 from django.contrib.auth.models import Group
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
@@ -116,3 +117,76 @@ def test_avoids_n_plus_one_on_user_groups(client):
         if re.search(r"\bauth_user_groups\b", query["sql"], re.IGNORECASE)
     ]
     assert len(user_group_queries) <= 2
+
+
+def _select_queries_matching(captured, pattern: str):
+    return [
+        query
+        for query in captured.captured_queries
+        if re.search(pattern, query["sql"], re.IGNORECASE)
+        and re.search(r"^\s*SELECT\b", query["sql"], re.IGNORECASE)
+    ]
+
+
+@pytest.mark.django_db
+def test_avoids_n_plus_one_on_flag_evaluation(client):
+    """
+    Batch-load FRONTEND_* flags once (plus M2M prefetch) instead of one
+    Flag.get() / Redis round-trip per flag via waffle.flag_is_active.
+    """
+    prefix = settings.WAFFLE_FLAG_PREFIX
+    user = UserFactory.create()
+    group = Group.objects.create(name="frontend-settings-batch-group")
+    user.groups.add(group)
+
+    flag_count = 12
+    for index in range(flag_count):
+        flag = FlagFactory.create(name=f"{prefix}BATCH_FLAG_{index}")
+        flag.groups.add(group)
+
+    client.force_login(user)
+
+    with CaptureQueriesContext(connection) as captured:
+        response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["flags"]) >= flag_count
+    assert all(
+        response.data["flags"][f"BATCH_FLAG_{index}"] for index in range(flag_count)
+    )
+
+    # Primary flag table: a single filtered SELECT (not one get-by-name per flag).
+    primary_flag_selects = _select_queries_matching(
+        captured, r'FROM\s+"?waffle_flag"?\s'
+    )
+    assert len(primary_flag_selects) == 1
+
+    # M2M membership loaded in bulk via prefetch_related, not per flag.
+    flag_users_selects = _select_queries_matching(captured, r"\bwaffle_flag_users\b")
+    flag_groups_selects = _select_queries_matching(captured, r"\bwaffle_flag_groups\b")
+    assert len(flag_users_selects) <= 1
+    assert len(flag_groups_selects) <= 1
+
+
+@pytest.mark.django_db
+def test_flag_query_count_does_not_grow_with_flag_count(client):
+    prefix = settings.WAFFLE_FLAG_PREFIX
+    user = UserFactory.create()
+    client.force_login(user)
+
+    def measure(count: int) -> int:
+        FlagModel = waffle.get_waffle_flag_model()
+        FlagModel.objects.filter(name__startswith=f"{prefix}SCALE_").delete()
+        for index in range(count):
+            FlagFactory.create(name=f"{prefix}SCALE_{index}", everyone=True)
+
+        with CaptureQueriesContext(connection) as captured:
+            response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        return len(captured.captured_queries)
+
+    few = measure(3)
+    many = measure(15)
+    # Bounded evaluation: adding flags must not add a linear number of queries.
+    assert many - few <= 2


### PR DESCRIPTION
## Motivation and context for the change

Alice `GET /api/frontend-settings/` was still slow in Datadog APM (~250ms avg, ~550ms p95) with dozens of repeated Redis GETs on `waffle:2.7.*` keys per request.

**Why PR #11 did not fix this:** that change only removed the SQL N+1 on `request.user.groups` (one `auth_user_groups` query per flag). It left the evaluation loop as “list flag **names**, then call `waffle.flag_is_active(request, name)` once per name.” Each call does `Flag.get(name)` → one Redis GET (and on miss, a DB get). For user/group-targeted flags, waffle’s `_get_user_ids` / `_get_group_ids` can add more per-flag Redis GETs. So after #11, Postgres group lookups were bounded, but **per-flag Redis round-trips remained** — that is what Datadog still showed.

**Why this PR fixes it:** we stop resolving flags by name. We load matching flag rows in **one** queryset with `prefetch_related("users", "groups")`, then call `flag.is_active(request)` on those instances. That removes N× `Flag.get()`. We also bind `_get_user_ids` / `_get_group_ids` to the prefetched id sets so membership checks stay in memory and skip waffle’s per-flag Redis M2M caches. PR #11’s request-local user-groups cache is kept.

**Review path:** `frontend_settings.views.settings` → `get_flags` → `_request_with_cached_user_groups` → batch queryset + prefetch → `_evaluate_flags` / `_bind_prefetched_membership` → `flag.is_active`.

## A clear description of the change

- Refactor `get_flags` to batch-load `FRONTEND_*` (configurable prefix) flags with `prefetch_related("users", "groups")` instead of `values_list("name")` + `flag_is_active` per name.
- Bind prefetched users/groups membership onto each flag before `is_active`, so waffle evaluation does not hit Redis/DB per flag for M2M.
- Keep the existing cached-user-groups adapter (PR #11 behavior), extracted as `_request_with_cached_user_groups`.
- Add regression tests that assert a single primary `waffle_flag` SELECT, bounded M2M prefetches, and that total query count does not grow linearly with flag count.

## Testing

- [x] The change is covered with automated tests

#### Testing instructions


## Rollback

- [x] The change can be automatically rolled back

#### Rollback instructions

Revert this PR / release and pin consumers (e.g. Alice) back to the previous `django-frontend-settings` version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved feature-flag evaluation efficiency by reducing database queries.
  * Prevented query counts from increasing linearly as more flags are configured.
* **Bug Fixes**
  * Improved loading of feature-flag user and group memberships during evaluation.
  * Added regression coverage to ensure efficient flag evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->